### PR TITLE
Add ifuse

### DIFF
--- a/Formula/ifuse-mac.rb
+++ b/Formula/ifuse-mac.rb
@@ -1,0 +1,32 @@
+require_relative "../require/macfuse"
+
+class IfuseMac < Formula
+  desc "FUSE module for iOS devices"
+  homepage "https://www.libimobiledevice.org/"
+  url "https://github.com/libimobiledevice/ifuse/archive/1.1.4.tar.gz"
+  sha256 "2a00769e8f1d8bad50898b9d00baf12c8ae1cda2d19ff49eaa9bf580e5dbe78c"
+  license "LGPL-2.1"
+  head "https://cgit.sukimashita.com/ifuse.git"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "glib"
+  depends_on "libimobiledevice"
+  depends_on "libplist"
+  depends_on MacfuseRequirement
+  depends_on :macos
+
+  def install
+    system "./autogen.sh"
+    system "./configure", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    # Actual test of functionality requires osxfuse, so test for expected failure instead
+    assert_match "ERROR: No device found!", shell_output("#{bin}/ifuse --list-apps", 1)
+  end
+end

--- a/Formula/ifuse-mac.rb
+++ b/Formula/ifuse-mac.rb
@@ -5,7 +5,7 @@ class IfuseMac < Formula
   homepage "https://www.libimobiledevice.org/"
   url "https://github.com/libimobiledevice/ifuse/archive/1.1.4.tar.gz"
   sha256 "2a00769e8f1d8bad50898b9d00baf12c8ae1cda2d19ff49eaa9bf580e5dbe78c"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
   head "https://cgit.sukimashita.com/ifuse.git"
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
This pull request adds support for [ifuse](https://github.com/libimobiledevice/ifuse).

The formula was copied from the [commit](https://github.com/Homebrew/homebrew-core/blob/e2c833d326c45d9aaf4e26af6dd8b2f31564dc04/Formula/ifuse.rb) in Homebrew before it disabled on macOS. The bottle code was removed and the `MacfuseRequirement` code was added.