### PR TITLE
adjust macFUSE capitalization

### DIFF
--- a/Formula/s3ql-mac.rb
+++ b/Formula/s3ql-mac.rb
@@ -149,7 +149,7 @@ class S3qlMac < Formula
   def caveats
     <<~EOS
       This formula is outdated, and is provided only as a courtesy.
-      It cannot be updated until MacFUSE supports FUSE API version 3.
+      It cannot be updated until macFUSE supports FUSE API version 3.
 
       If security issues are discovered with this old software,
       it may be removed without notice.

--- a/Formula/sshfs-mac.rb
+++ b/Formula/sshfs-mac.rb
@@ -40,7 +40,7 @@ class SshfsMac < Formula
   def caveats
     <<~EOS
       This formula is outdated, and is provided only as a courtesy.
-      It cannot be updated until MacFUSE supports FUSE API version 3.
+      It cannot be updated until macFUSE supports FUSE API version 3.
 
       If security issues are discovered with this old software,
       it may be removed without notice.

--- a/require/macfuse.rb
+++ b/require/macfuse.rb
@@ -17,7 +17,11 @@ class MacfuseRequirement < Requirement
   end
 
   def message
-    "This formula requires MacFUSE. Please run `brew install --cask macfuse` first."
+    "This formula requires macFUSE. Please run `brew install --cask macfuse` first."
+  end
+
+  def display_s
+    "macFUSE"
   end
 end
 


### PR DESCRIPTION
Display as "macFUSE" in formula caveats and requirements.
```
$ brew info sshfs-mac
gromgit/fuse/sshfs-mac: stable 2.10
File system client based on SSH File Transfer Protocol
https://github.com/libfuse/sshfs
/usr/local/Cellar/sshfs-mac/2.10_1 (8 files, 104.2KB) *
  Built from source on 2021-04-27 at 14:29:22
From: https://github.com/gromgit/homebrew-fuse/blob/HEAD/Formula/sshfs-mac.rb
License: LGPL-2.1-only or GPL-2.0-only
==> Dependencies
Build: autoconf ✔, automake ✔, libtool ✔, pkg-config ✔
Required: glib ✘
==> Requirements
Required: macFUSE ✔, macOS ✔
==> Caveats
This formula is outdated, and is provided only as a courtesy.
It cannot be updated until macFUSE supports FUSE API version 3.

If security issues are discovered with this old software,
it may be removed without notice.
```