### PR TITLE
dislocker-mac: switch to mbedtls@2

### DIFF
--- a/Formula/dislocker-mac.rb
+++ b/Formula/dislocker-mac.rb
@@ -17,7 +17,7 @@ class DislockerMac < Formula
   depends_on "cmake" => :build
   depends_on MacfuseRequirement
   depends_on :macos
-  depends_on "mbedtls"
+  depends_on "mbedtls@2"
 
   # Fix OSXFUSE-isms
   patch :DATA


### PR DESCRIPTION
currently dislocker needs mbedtls@2 (or build fails with error`mbedtls/config.h file not found`)

related: https://github.com/Homebrew/homebrew-core/commit/8f6e935fb3ce5a99c78d9021ebdcd4a8bd9330fb