### PR TITLE
Update Mounty Version to 2.3

### DIFF
--- a/Casks/mounty.rb
+++ b/Casks/mounty.rb
@@ -8,8 +8,8 @@ cask "mounty" do
     end
   end
   on_big_sur :or_newer do
-    version "2.1"
-    sha256 "2aeeb012ebaf1d60767d268e48c8b90726e3f05b2e35945f4293c11fbad84381"
+    version "2.3"
+    sha256 "452326c4b96b231f62e3840e71f9b2bca0f0f2af4f7f4ddeaef54af5459b43e2"
 
     depends_on cask: "macfuse"
     depends_on formula: "gromgit/fuse/ntfs-3g-mac"


### PR DESCRIPTION
- password to remount in r/w mode is now stored in keychain for your convenience
- corrections and additions to Italian translation, thanks to Walter Ferlazzo from JAW Software
- fixed some potential memory leaks