### PR TITLE
hfsfuse-mac 0.242 (new formula)

### DIFF
--- a/Formula/hfsfuse-mac.rb
+++ b/Formula/hfsfuse-mac.rb
@@ -1,0 +1,24 @@
+require_relative "../require/macfuse"
+
+class HfsfuseMac < Formula
+  desc "FUSE driver for HFS+ filesystems (read-only)"
+  homepage "https://github.com/0x09/hfsfuse"
+  url "https://github.com/0x09/hfsfuse/releases/download/0.242/hfsfuse-0.242.tar.gz"
+  sha256 "2cda7fd5d2fd3419c24907c1f59d04230162ce9491a65553c3d6254677ee62f3"
+  license all_of: ["BSD-2-Clause", "MIT"]
+  head "https://github.com/0x09/hfsfuse.git"
+
+  depends_on "lzfse"
+  depends_on MacfuseRequirement
+  depends_on :macos
+
+  def install
+    setup_fuse
+    system "make", "install", "prefix=#{prefix}"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/hfsfuse --version 2>&1")
+    system bin/"hfsdump"
+  end
+end


### PR DESCRIPTION
Adds [hfsfuse](https://github.com/0x09/hfsfuse). Though not particularly useful on its own given macOS still supports HFS+, `hfsdump` or the options for `hfsfuse` might be.