### PR TITLE
rclone-mac: 1.66.0

### DIFF
--- a/Formula/rclone-mac.rb
+++ b/Formula/rclone-mac.rb
@@ -30,10 +30,14 @@ class RcloneMac < Formula
     system bin/name.to_s, "genautocomplete", "bash", "#{name}.bash"
     system bin/name.to_s, "genautocomplete", "zsh", "_rclone"
     system bin/name.to_s, "genautocomplete", "zsh", "_#{name}"
+    system bin/name.to_s, "genautocomplete", "fish", "rclone.fish"
+    system bin/name.to_s, "genautocomplete", "fish", "#{name}.fish"
     bash_completion.install "rclone.bash" => "rclone"
     bash_completion.install "#{name}.bash" => name.to_s
     zsh_completion.install "_rclone"
     zsh_completion.install "_#{name}"
+    fish_completion.install "rclone.fish" => "rclone"
+    fish_completion.install "#{name}.fish" => name.to_s
   end
 
   def caveats

--- a/Formula/rclone-mac.rb
+++ b/Formula/rclone-mac.rb
@@ -8,13 +8,6 @@ class RcloneMac < Formula
   license "MIT"
   head "https://github.com/rclone/rclone.git"
 
-  bottle do
-    root_url "https://github.com/gromgit/homebrew-fuse/releases/download/rclone-mac-1.62.2"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "83fd26fe9ac9fea9ce01c50e51e68e15de4d16486960a8260200a9305da5dfe7"
-    sha256 cellar: :any_skip_relocation, monterey:       "eb442e32a816e0eb7293e8c6b41b63bcc85653b453660da412972665f35bcbb7"
-    sha256 cellar: :any_skip_relocation, big_sur:        "d9df31fc8adcb9e123cf8c9c9ee87ea878bd12053ba86eb7279ad35a863dbf5a"
-  end
-
   depends_on "go" => :build
   depends_on MacfuseRequirement
   depends_on :macos

--- a/Formula/rclone-mac.rb
+++ b/Formula/rclone-mac.rb
@@ -30,10 +30,6 @@ class RcloneMac < Formula
     system bin/name.to_s, "genautocomplete", "bash", "#{name}.bash"
     system bin/name.to_s, "genautocomplete", "zsh", "_rclone"
     system bin/name.to_s, "genautocomplete", "zsh", "_#{name}"
-    inreplace "#{name}.bash" do |s|
-      s.gsub! "commands=(\"rclone\")", "commands=(\"#{name}\")"
-      s.gsub!(/(-F __start_rclone) rclone$/, "\\1 #{name}")
-    end
     bash_completion.install "rclone.bash" => "rclone"
     bash_completion.install "#{name}.bash" => name.to_s
     zsh_completion.install "_rclone"

--- a/Formula/rclone-mac.rb
+++ b/Formula/rclone-mac.rb
@@ -3,8 +3,8 @@ require_relative "../require/macfuse"
 class RcloneMac < Formula
   desc "Rsync for cloud storage (with macOS FUSE mount support)"
   homepage "https://rclone.org/"
-  url "https://github.com/rclone/rclone/archive/v1.62.2.tar.gz"
-  sha256 "6741c81ae5b5cb48a04055f280f6e220ed4b35d26fe43f59510d0f7740044748"
+  url "https://github.com/rclone/rclone/archive/v1.66.0.tar.gz"
+  sha256 "9249391867044a0fa4c5a948b46a03b320706b4d5c4d59db9d4aeff8d47cade2"
   license "MIT"
   head "https://github.com/rclone/rclone.git"
 


### PR DESCRIPTION
This addresses #49 and includes #54.