### PR TITLE
afuse-mac 0.5.0

### DIFF
--- a/Formula/afuse-mac.rb
+++ b/Formula/afuse-mac.rb
@@ -3,8 +3,9 @@ require_relative "../require/macfuse"
 class AfuseMac < Formula
   desc "Automounting file system implemented in userspace with FUSE"
   homepage "https://github.com/pcarrier/afuse/"
-  url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/afuse/afuse-0.4.1.tar.gz"
-  sha256 "c6e0555a65d42d3782e0734198bbebd22486386e29cb00047bc43c3eb726dca8"
+  url "https://github.com/pcarrier/afuse.git",
+      tag:      "v0.5.0",
+      revision: "d7f07c32e58850fa092bb98b53c5c570fed8be69"
   license "GPL-2.0-only"
 
   bottle do
@@ -16,12 +17,15 @@ class AfuseMac < Formula
     sha256 cellar: :any,                 mojave:         "577023bd06623a90ca245be88fbb49041a71cc1e4852195dc5d9d3b2bbdaf617"
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
   depends_on "pkg-config" => :build
   depends_on MacfuseRequirement
   depends_on :macos
 
   def install
     setup_fuse
+    system "./autogen.sh"
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"
   end


### PR DESCRIPTION
Adjusts URL to pull from Git tag. Tested on macOS 14.7.3 ARM.