### PR TITLE
s3fs-mac 1.97

### DIFF
--- a/Formula/s3fs-mac.rb
+++ b/Formula/s3fs-mac.rb
@@ -3,8 +3,8 @@ require_relative "../require/macfuse"
 class S3fsMac < Formula
   desc "FUSE-based file system backed by Amazon S3"
   homepage "https://github.com/s3fs-fuse/s3fs-fuse/wiki"
-  url "https://github.com/s3fs-fuse/s3fs-fuse/archive/refs/tags/v1.95.tar.gz"
-  sha256 "0c97b8922f005500d36f72aee29a1345c94191f61d795e2a7b79fb7e3e6f5517"
+  url "https://github.com/s3fs-fuse/s3fs-fuse/archive/refs/tags/v1.97.tar.gz"
+  sha256 "28413457cbf923b9b81e546caffabb8edd5c18f263e698ad86f564fd4b5b344d"
   license "GPL-2.0-or-later"
   head "https://github.com/s3fs-fuse/s3fs-fuse.git", branch: "master"
 
@@ -35,6 +35,9 @@ class S3fsMac < Formula
 
   def install
     setup_fuse
+    # s3fs >= 1.96 configure only probes the fuse-t and fuse3 pkg-config modules,
+    # but its macOS code still uses the FUSE 2 API; use macFUSE's fuse module instead
+    inreplace "configure.ac", "[fuse3 >= ${min_fuse_version}", "[fuse >= ${min_fuse_version}"
     system "./autogen.sh"
     system "./configure", "--with-gnutls", *std_configure_args
     system "make", "install"


### PR DESCRIPTION
s3fs >= 1.96 targets FUSE-T on macOS, and its configure only probes the
fuse-t and fuse3 pkg-config modules.  macFUSE 5.x's fuse3 module
satisfies configure, but s3fs pins FUSE_USE_VERSION 26 on __APPLE__, so
its FUSE 2 API code fails to compile against real libfuse3 headers
("#error only API version 30 or greater is supported", etc.), leaving
test-bot green-but-bottleless and breaking brew pr-pull.

The sources contain no FUSE-T-specific code, so build the same __APPLE__
FUSE 2 code path against macFUSE's still-shipped FUSE 2 API, as 1.95
did, by pointing configure at the fuse module (macFUSE's 2.9.9
satisfies the Darwin minimum of 2.7.3).